### PR TITLE
Adding additional NSIS install methods (Scoop, Winget) to windows-ins…

### DIFF
--- a/website/docs/guides/windows-installer.mdx
+++ b/website/docs/guides/windows-installer.mdx
@@ -18,13 +18,7 @@ Wails supports generating Windows installers using the [NSIS installer](https://
 
 The installer is available on the [NSIS Download](https://nsis.sourceforge.io/Download) page.
 
-If you use the chocolatey package manager, run the following script:
-
-```
-choco install nsis
-```
-
-Or, you can install with [Scoop](https://scoop.sh/) (which will automatically add it to your PATH):
+You can install with [Scoop](https://scoop.sh/) (which will automatically add it to your PATH):
 
 ```
 scoop add bucket extras
@@ -37,7 +31,13 @@ Or, you can use Winget (on Windows 10+):
 winget install NSIS.NSIS --silent
 ```
 
-If you install NSIS manually, you need to add the _Bin_ folder, which contains `makensis.exe`, in your NSIS installation to your path.
+If you use the chocolatey package manager, run the following script:
+
+```
+choco install nsis
+```
+
+**NOTE:** If you install NSIS manually, you need to add the _Bin_ folder, which contains `makensis.exe`, in your NSIS installation to your path.
 [Here](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/) is a good tutorial on how to add to path on Windows.
 
 ### Linux

--- a/website/docs/guides/windows-installer.mdx
+++ b/website/docs/guides/windows-installer.mdx
@@ -24,6 +24,19 @@ If you use the chocolatey package manager, run the following script:
 choco install nsis
 ```
 
+Or, you can install with [Scoop](https://scoop.sh/) (which will automatically add it to your PATH):
+
+```
+scoop add bucket extras
+scoop install nsis
+```
+
+Or, you can use Winget (on Windows 10+):
+
+```
+winget install NSIS.NSIS --silent
+```
+
 If you install NSIS manually, you need to add the _Bin_ folder, which contains `makensis.exe`, in your NSIS installation to your path.
 [Here](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/) is a good tutorial on how to add to path on Windows.
 


### PR DESCRIPTION
Adding Scoop and Winget package managers to the list of methods by which NSIS can be installed.